### PR TITLE
Fix crash for streaming old states

### DIFF
--- a/src/LatticesProcessor.cpp
+++ b/src/LatticesProcessor.cpp
@@ -161,6 +161,8 @@ void LatticesProcessor::setStateInformation(const void *data, int sizeInBytes)
             originalRefFreq = xmlState->getDoubleAttribute("freq");
 
             maxDistance = xmlState->getIntAttribute("md");
+            if (maxDistance < 1)
+                maxDistance = 24;
 
             int tx = xmlState->getIntAttribute("xp");
             int ty = xmlState->getIntAttribute("yp");


### PR DESCRIPTION
If a state is missing MaxDistance or has an otherwise invalid distance streamed, set to the default so the subsequent toParam calls don't generate NaNs